### PR TITLE
test: replace deprecated @MockBean in BookControllerTest

### DIFF
--- a/src/test/java/com/example/bookapi/controller/BookControllerTest.java
+++ b/src/test/java/com/example/bookapi/controller/BookControllerTest.java
@@ -1,14 +1,18 @@
 package com.example.bookapi.controller;
 
+import com.example.bookapi.controller.BookController;
 import com.example.bookapi.model.Book;
 import com.example.bookapi.service.BookService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
@@ -17,12 +21,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BookController.class)
+@Import(BookControllerTest.MockedBookServiceConfig.class)
 public class BookControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Autowired
     private BookService bookService;
 
     private List<Book> mockBooks;
@@ -32,13 +37,21 @@ public class BookControllerTest {
         mockBooks = List.of(
                 new Book(1L, "Libro Test", "Autor Test", "123", 2021, "http://url")
         );
+        when(bookService.getAllBooks()).thenReturn(mockBooks);
     }
 
     @Test
     void shouldReturnAllBooks() throws Exception {
-        when(bookService.getAllBooks()).thenReturn(mockBooks);
-
         mockMvc.perform(get("/books"))
                 .andExpect(status().isOk());
+    }
+
+    @TestConfiguration
+    static class MockedBookServiceConfig {
+        @Bean
+        @Primary
+        public BookService bookService() {
+            return Mockito.mock(BookService.class);
+        }
     }
 }


### PR DESCRIPTION
se reemplazó la anotación @MockBean (deprecated desde Spring Boot 3.4.0) en BookControllerTest.

Se agregó una configuración personalizada usando @TestConfiguration para inyectar manualmente un mock de BookService.